### PR TITLE
Change %e to %d to check for today's date

### DIFF
--- a/letsencrypt-edgemax.sh
+++ b/letsencrypt-edgemax.sh
@@ -34,7 +34,7 @@ lighttpd_pem=/config/auth/erx.yourdomain.com.pem
 sudo LE_WORKING_DIR=${home} ${home}/acme.sh --renew -d ${domain} --days 70 ${force} > /dev/null
 
 _rv=$?
-_today=$(date +%Y-%m-%e)
+_today=$(date +%Y-%m-%d)
 _certm=$(sudo stat -c %y ${home}/${domain}/${domain}.cer|awk '{print $1}')
 
 if (( $_rv != 0 )) || [[ "$_today" != "$_certm" ]]; then


### PR DESCRIPTION
This is to fix the issue where we have a single digit date is compared with the `stat` output.

Using `January 4, 2020` for example:

Previously (using `%e`):
- `_today` = `2020-01- 4` (notice the space before `4`)
- `stat` output =  `2020-01-04`

After this change (using `%d`):
- `_today` = `2020-01-04`
- `stat` output =  `2020-01-04`

Router: EdgeRouter X SFP
EdgeOS version: 2.0.8